### PR TITLE
[TASK] CriteriaOption: Use default-tablename

### DIFF
--- a/Configuration/TCA/Forum/Criteria.php
+++ b/Configuration/TCA/Forum/Criteria.php
@@ -25,7 +25,7 @@ $TCA['tx_mmforum_domain_model_forum_criteria'] = array(
 			'label'   => 'LLL:EXT:mm_forum/Resources/Private/Language/locallang_db.xml:tx_mmforum_domain_model_forum_criteria_options',
 			'config' => array(
 				'type' => 'inline',
-				'foreign_table' => 'tx_mmforum_domain_model_forum_criteria_options',
+				'foreign_table' => 'tx_mmforum_domain_model_forum_criteriaoption',
 				'foreign_field' => 'criteria',
 				'maxitems'      => 9999,
 				'foreign_sortby' => 'sorting',
@@ -42,7 +42,7 @@ $TCA['tx_mmforum_domain_model_forum_criteria'] = array(
 			'config'  => array(
 				'type'          => 'select',
 				'maxitems'      => 1,
-				'foreign_table' => 'tx_mmforum_domain_model_forum_criteria_options',
+				'foreign_table' => 'tx_mmforum_domain_model_forum_criteriaoption',
 				'foreign_class' => 'Tx_MmForum_Domain_Model_Forum_CriteriaOption',
 			)
 		),

--- a/Configuration/TCA/Forum/CriteriaOption.php
+++ b/Configuration/TCA/Forum/CriteriaOption.php
@@ -1,8 +1,8 @@
 <?php
 if (!defined ('TYPO3_MODE')) 	die ('Access denied.');
 
-$TCA['tx_mmforum_domain_model_forum_criteria_options'] = array(
-	'ctrl' => $TCA['tx_mmforum_domain_model_forum_criteria_options']['ctrl'],
+$TCA['tx_mmforum_domain_model_forum_criteriaoption'] = array(
+	'ctrl' => $TCA['tx_mmforum_domain_model_forum_criteriaoption']['ctrl'],
 	'interface' => array(
 		'showRecordFieldList' => 'name,criteria,sorting'
 	),

--- a/Configuration/TCA/Forum/Topic.php
+++ b/Configuration/TCA/Forum/Topic.php
@@ -193,7 +193,7 @@ $TCA['tx_mmforum_domain_model_forum_topic'] = array(
 				'type'          => 'select',
 				'size'          => 10,
 				'maxitems'      => 99999,
-				'foreign_table' => 'tx_mmforum_domain_model_forum_criteria_options',
+				'foreign_table' => 'tx_mmforum_domain_model_forum_criteriaoption',
 				'MM' => 'tx_mmforum_domain_model_forum_criteria_topic_options'
 			),
 		),

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -194,13 +194,6 @@ config.tx_extbase.persistence.classes {
 		}
 	}
 
-	Tx_MmForum_Domain_Model_Forum_CriteriaOption {
-		mapping {
-			tableName = tx_mmforum_domain_model_forum_criteria_options
-			recordType = 1
-		}
-	}
-
 	Tx_MmForum_Domain_Model_User_PrivateMessagesText {
 		mapping {
 			tableName = tx_mmforum_domain_model_user_privatemessages_text

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -592,8 +592,8 @@ $TCA['tx_mmforum_domain_model_forum_criteria'] = array(
 	)
 );
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_mmforum_domain_model_forum_criteria_options');
-$TCA['tx_mmforum_domain_model_forum_criteria_options'] = array(
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_mmforum_domain_model_forum_criteriaoptions');
+$TCA['tx_mmforum_domain_model_forum_criteriaoptions'] = array(
 	'ctrl' => array(
 		'title' => 'LLL:EXT:mm_forum/Resources/Private/Language/locallang_db.xml:tx_mmforum_domain_model_forum_criteria_options',
 		'label' => 'name',

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -505,9 +505,9 @@ CREATE TABLE tx_mmforum_domain_model_forum_criteria_forum (
 
 
 #
-# Table structure for table 'tx_mmforum_domain_model_forum_criteria_options'
+# Table structure for table 'tx_mmforum_domain_model_forum_criteriaoption'
 #
-CREATE TABLE tx_mmforum_domain_model_forum_criteria_options (
+CREATE TABLE tx_mmforum_domain_model_forum_criteriaoption (
   uid int(11) unsigned NOT NULL auto_increment,
   pid int(11) unsigned NOT NULL default '0',
   tstamp int(11) unsigned NOT NULL default '0',


### PR DESCRIPTION
Each row in that table is a single option, so use the
singular-name. Default-name also doesn't have an underscore.