### PR TITLE
[BUGFIX] Fix new-overlay for forum and topic (Followup)

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -471,6 +471,8 @@ plugin.tx_mmforum.renderer.icons {
 	forum_new {
 		10.file = EXT:mm_forum/Resources/Public/Images/Icons/Forum/BaseIcon.png
 
+		# locked has higher priority: no permission to access that forum
+		21 >
 		21 = IMG_RESOURCE
 		21.file = EXT:mm_forum/Resources/Public/Images/Icons/Forum/OverlayLocked.png
 		21.stdWrap.wrap = <div class="tx-mmforum-icon-overlay-bl" style="background-image: url(|)" title="closed & new"></div>
@@ -515,15 +517,17 @@ plugin.tx_mmforum.renderer.icons {
 	topic_new  {
 		10.file = EXT:mm_forum/Resources/Public/Images/Icons/Topic/BaseIcon.png
 
+		# new has higher priority: even if topic is closed, it's more important that you have unread messages
+		22 >
 		22 = IMG_RESOURCE
-		22.file = EXT:mm_forum/Resources/Public/Images/Icons/Topic/OverlayLocked.png
+		22.file = EXT:mm_forum/Resources/Public/Images/Icons/Topic/OverlayNew.png
 		22.stdWrap.wrap = <div class="tx-mmforum-icon-overlay-bl" style="background-image: url(|)" title="closed & new"></div>
 		22.stdWrap.if.isTrue.field = closed
 
 		26 = IMG_RESOURCE
 		26.file = EXT:mm_forum/Resources/Public/Images/Icons/Topic/OverlayNew.png
 		26.stdWrap.wrap = <div class="tx-mmforum-icon-overlay-bl" style="background-image: url(|)" title="new"></div>
-		22.stdWrap.if.isFalse.field = closed
+		26.stdWrap.if.isFalse.field = closed
 	}
 
 


### PR DESCRIPTION
* fix a typo in the TypoScript
* for forum "locked" has higher priority (no access)
* for topic "new" has higher priority (unread messages)