### PR TITLE
[TASK] Pass some general plugin-settings through to parser-service

### DIFF
--- a/Classes/TextParser/Service/QuoteParserService.php
+++ b/Classes/TextParser/Service/QuoteParserService.php
@@ -120,6 +120,7 @@ class Tx_MmForum_TextParser_Service_QuoteParserService extends Tx_MmForum_TextPa
 		$this->view->setTemplatePathAndFilename(Tx_MmForum_Utility_File::replaceSiteRelPath($this->settings['template']));
 		$this->view->assign('quote', trim($matches[1]));
 		$this->view->assign('post', null);
+		$this->view->assign('settings', $this->settings);
 		return $this->view->render();
 	}
 
@@ -143,6 +144,7 @@ class Tx_MmForum_TextParser_Service_QuoteParserService extends Tx_MmForum_TextPa
 		}
 
 		$this->view->assign('quote', trim($matches[2]));
+		$this->view->assign('settings', $this->settings);
 		return $this->view->render();
 	}
 

--- a/Classes/TextParser/TextParserService.php
+++ b/Classes/TextParser/TextParserService.php
@@ -164,6 +164,7 @@ class Tx_MmForum_TextParser_TextParserService extends Tx_MmForum_Service_Abstrac
 		}
 
 		$this->settings = $this->typoscriptReader->loadTyposcriptFromPath($configurationPath);
+		$mmforumGlobalSettings = $this->typoscriptReader->loadTyposcriptFromPath('plugin.tx_mmforum.settings');
 		foreach ($this->settings['enabledServices.'] as $key => $className) {
 			if (substr($key, -1, 1) === '.') {
 				continue;
@@ -172,7 +173,15 @@ class Tx_MmForum_TextParser_TextParserService extends Tx_MmForum_Service_Abstrac
 			/** @var $newService Tx_MmForum_TextParser_Service_AbstractTextParserService */
 			$newService = $this->objectManager->get($className);
 			if ($newService instanceof Tx_MmForum_TextParser_Service_AbstractTextParserService) {
-				$newService->setSettings((array)$this->settings['enabledServices.'][$key . '.']);
+				$settings = array();
+				$globalSettingsToCopy = array('pids.');
+				foreach($globalSettingsToCopy as $settingToCopy) {
+					if (isset($mmforumGlobalSettings[$settingToCopy])) {
+						$settings = array_merge($settings, array(rtrim($settingToCopy, '.') => $mmforumGlobalSettings[$settingToCopy]));
+					}
+				}
+				$settings = array_merge($settings, (array)$this->settings['enabledServices.'][$key . '.']);
+				$newService->setSettings($settings);
 				$newService->setControllerContext($this->controllerContext);
 				$this->parsingServices[] = $newService;
 			} else {


### PR DESCRIPTION
In templates of the parser-services currently there is no access
to things like {settings.pids.UserShow}, but it is already used
in a template.

Pass through some global settings (only "pids" for now) and merge
them with the parser-service-settings.