### PR TITLE
Bugfix: className must not start with a backslash

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -138,9 +138,11 @@ abstract class AbstractController extends ActionController {
 		$this->className = array_pop(explode('_', get_class($this)));
 		$this->localSettings = $this->settings[lcfirst($this->className)];
 
-		foreach ($this->settings['pids'] as &$value) {
-			if (!$value) {
-				$value = $GLOBALS['TSFE']->id;
+		if (!empty($this->settings['pids'])) {
+			foreach ($this->settings['pids'] as &$value) {
+				if (!$value) {
+					$value = $GLOBALS['TSFE']->id;
+				}
 			}
 		}
 	}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -60,7 +60,7 @@ $_EXTKEY = 'typo3_forum';
 );
 
 # TCE-Main hook for clearing all typo3_forum caches
-$TYPO3_CONF_VARS['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = '\Mittwald\Typo3Forum\Cache\CacheManager->clearAll';
+$TYPO3_CONF_VARS['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'Mittwald\Typo3Forum\Cache\CacheManager->clearAll';
 
 if (!is_array($TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main'])) {
 	$TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main'] = [];
@@ -89,8 +89,8 @@ $TYPO3_CONF_VARS['FE']['eID_include']['typo3_forum'] = 'EXT:typo3_forum/Classes/
 // Connect signals to slots. Some parts of extbase suck, but the signal-slot
 // pattern is really cool! :P
 $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\SignalSlot\Dispatcher');
-$signalSlotDispatcher->connect('\Mittwald\Typo3Forum\Domain\Model\Forum\Post', 'postCreated', '\Mittwald\Typo3Forum\Service\Notification\SubscriptionListener', 'onPostCreated');
-$signalSlotDispatcher->connect('\Mittwald\Typo3Forum\Domain\Model\Forum\Topic', 'topicCreated', '\Mittwald\Typo3Forum\Service\Notification\SubscriptionListener', 'onTopicCreated');
+$signalSlotDispatcher->connect('Mittwald\Typo3Forum\Domain\Model\Forum\Post', 'postCreated', 'Mittwald\Typo3Forum\Service\Notification\SubscriptionListener', 'onPostCreated');
+$signalSlotDispatcher->connect('Mittwald\Typo3Forum\Domain\Model\Forum\Topic', 'topicCreated', 'Mittwald\Typo3Forum\Service\Notification\SubscriptionListener', 'onTopicCreated');
 
 // adding scheduler tasks
 


### PR DESCRIPTION
For compatibility with TYPO3 7.5