### PR TITLE
[BUGFIX] Fixed interface name (camel case)

### DIFF
--- a/Classes/Domain/Model/ReadableInterface.php
+++ b/Classes/Domain/Model/ReadableInterface.php
@@ -27,7 +27,7 @@ namespace Mittwald\Typo3Forum\Domain\Model;
 /**
  * Interface definition for objects that can be read by individual users.
  */
-interface Readableinterface {
+interface ReadableInterface {
 
 	/**
 	 * Adds a reader to this object.


### PR DESCRIPTION
Interface "ReadableInterface" is not found because there is a typo in the name "Readableinterface" (lowercase name).