### PR TITLE
[BUGFIX] Corrected invalid version requirement and added static_info_tables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 		"bin-dir": "bin"
 	},
 	"require": {
-		"typo3/cms-core": ">=6.2.*"
+		"typo3/cms-core": ">=6.2",
+		"typo3-ter/static-info-tables": "6.3.*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "4.7.*",


### PR DESCRIPTION
When using composer to install and deploy TYPO3 the current version requirement of the cms-core will give you an error: Skipped branch develop, Could not parse version constraint >=6.2.*: Invalid version string "6.2.*"
Also if static_info_tables are not required by another package they will be missing why it's important to have them as a requirement also.