### PR TITLE
[FIX] calling non-static Method getTypoScriptSetup() and AjaxController TCA Error

### DIFF
--- a/Classes/Ajax/Dispatcher.php
+++ b/Classes/Ajax/Dispatcher.php
@@ -26,6 +26,7 @@ namespace Mittwald\Typo3Forum\Ajax;
 
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Utility\EidUtility;
 use TYPO3\CMS\Extbase\Core\Bootstrap;
 use TYPO3\CMS\Extbase\Mvc\Dispatcher as ExtbaseDispatcher;
 use TYPO3\CMS\Extbase\Mvc\Web\RequestBuilder;
@@ -82,9 +83,9 @@ final class Dispatcher implements SingletonInterface {
 		$GLOBALS['TSFE'] = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController', $GLOBALS['TYPO3_CONF_VARS'], GeneralUtility::_GP('id'), GeneralUtility::_GP('type'), true);
 		$GLOBALS['TSFE']->initFEuser();
 		$GLOBALS['TSFE']->initUserGroups();
+		EidUtility::initTCA();
 		$GLOBALS['TSFE']->checkAlternativeIdMethods();
 		$GLOBALS['TSFE']->determineId();
-		$GLOBALS['TSFE']->getCompressedTCarray();
 		$GLOBALS['TSFE']->sys_page =  GeneralUtility::makeInstance('TYPO3\CMS\Frontend\Page\PageRepository');
 		$GLOBALS['TSFE']->initTemplate();
 		$GLOBALS['TSFE']->getConfigArray();
@@ -119,7 +120,6 @@ final class Dispatcher implements SingletonInterface {
 		$GLOBALS['TSFE']->forceTemplateParsing = TRUE;
 		$GLOBALS['TSFE']->initFEuser();
 		$GLOBALS['TSFE']->initUserGroups();
-		$GLOBALS['TSFE']->getCompressedTCarray();
 		$GLOBALS['TSFE']->no_cache = TRUE;
 		$GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
 		$GLOBALS['TSFE']->no_cache = FALSE;

--- a/Classes/Domain/Model/Forum/Topic.php
+++ b/Classes/Domain/Model/Forum/Topic.php
@@ -194,7 +194,8 @@ class Topic extends AbstractEntity implements AccessibleInterface, Subscribeable
 	 */
 	public function injectTyposcriptService(\TYPO3\CMS\Extbase\Service\TypoScriptService $typoScriptService) {
 		$this->typoScriptService = $typoScriptService;
-		$ts = $this->typoScriptService->convertTypoScriptArrayToPlainArray(\TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager::getTypoScriptSetup());
+		$fc = \TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager;
+		$ts = $this->typoScriptService->convertTypoScriptArrayToPlainArray($fc->getTypoScriptSetup());
 		$this->settings = $ts['plugin']['tx_typo3forum']['settings'];
 	}
 

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -590,6 +590,11 @@ page.includeJSFooter {
 	typo3forum = EXT:typo3_forum/Resources/Public/Javascript/forum.js
 }
 
+page.jsInline {
+ 10 = TEXT
+ 10.stdWrap.dataWrap = var currentPageUid ={TSFE:id};
+}
+
 module.tx_typo3forum.persistence {
 	storagePid = {$plugin.tx_typo3forum.persistence.storagePid}
 }


### PR DESCRIPTION
By adding new Topic it was throwing the error with calling a non-static method statically. Tested Typo3 7.6.4
