### PR TITLE
Stop AJAX Dispatcher from initializing TSFE twice

### DIFF
--- a/Classes/Ajax/Dispatcher.php
+++ b/Classes/Ajax/Dispatcher.php
@@ -111,15 +111,8 @@ final class Dispatcher implements SingletonInterface {
 
 		// The following code was adapted from the df_tools extension.
 		// Credits go to Stefan Galinski.
-		$GLOBALS['TSFE'] = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController',
-		$GLOBALS['TYPO3_CONF_VARS'], (int)$_GET['id'], 0);
-		$GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\Page\PageRepository');
 		$GLOBALS['TSFE']->getPageAndRootline();
-		$GLOBALS['TSFE']->initTemplate();
 		$GLOBALS['TSFE']->forceTemplateParsing = TRUE;
-		$GLOBALS['TSFE']->initFEuser();
-		$GLOBALS['TSFE']->initUserGroups();
-		EidUtility::initTCA();
 		$GLOBALS['TSFE']->no_cache = TRUE;
 		$GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
 		$GLOBALS['TSFE']->no_cache = FALSE;


### PR DESCRIPTION
The TypoScript Frontend Controller is initialized in 
```php
\Mittwald\Typo3Forum\Ajax\Dispatcher::initializeTsfe()
```
and 
```php
\Mittwald\Typo3Forum\Ajax\Dispatcher::initTYPO3()
```
later on, where the latter one overrides the former one. This leads to a broken TypoScript setup in *$GLOBALS['TSFE']->tmpl->setup* and causes the AJAX Controller to be unable to resolve root paths and the storage page ID. This is, why the menu buttons ('Subscribe', 'New topic', …) aren't ever displayed.