### PR TITLE
Don't test documentation build in CI run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,11 @@
 language: php
 
 php:
-#  - 5.5
-#  - 5.6
+  - 5.5
+  - 5.6
   - 7.0
 
 sudo: false
 
-addons:
-  apt:
-    packages:
-      - python-sphinx
-
-before_script:
-  - ln -s Index.rst Documentation/contents.rst
-
 script:
-  - >
-    cd Documentation &&
-    sphinx-build -C . output
+  - find Configuration Classes -name '*.php' | xargs -l1 php -l


### PR DESCRIPTION
@pstranghoener has different plans for the documentation. As the doc build is currently failing anyway, simply remove it for now.

Instead, add a simple test to check the correct syntax of PHP files in the repository. Just because I can.

Fixes #122.