### PR TITLE
use proper AJAX URL

### DIFF
--- a/Classes/Ajax/Dispatcher.php
+++ b/Classes/Ajax/Dispatcher.php
@@ -98,16 +98,6 @@ final class Dispatcher implements SingletonInterface {
 	 * Galinski.
 	 */
 	protected function initTYPO3() {
-		//Check which language should be used
-		$ts = $this->loadTS((int)$_GET['id']);
-		$languages = explode(',',$ts['plugin.']['tx_typo3forum.']['settings.']['allowedLanguages']);
-		$submittedLang = trim($_GET['language']);
-
-		if($submittedLang == false || !(array_search($submittedLang,$languages) || in_array('*',$languages))) {
-			$lang = "default";
-		} else {
-			$lang = $submittedLang;
-		}
 
 		// The following code was adapted from the df_tools extension.
 		// Credits go to Stefan Galinski.
@@ -121,10 +111,11 @@ final class Dispatcher implements SingletonInterface {
 			'sys_language_overlay' => 'hideNonTranslated',
 			'sys_language_softMergeIfNotBlank' => '',
 			'sys_language_softExclude' => '',
-			'language' => $lang,
+			'language' => $GLOBALS['TSFE']->tmpl->setup['config.']['language'],
 		];
 
 		$GLOBALS['TSFE']->settingLanguage();
+        $GLOBALS['TSFE']->settingLocale();
 	}
 
 

--- a/Classes/Ajax/Dispatcher.php
+++ b/Classes/Ajax/Dispatcher.php
@@ -103,7 +103,7 @@ final class Dispatcher implements SingletonInterface {
 		$languages = explode(',',$ts['plugin.']['tx_typo3forum.']['settings.']['allowedLanguages']);
 		$submittedLang = trim($_GET['language']);
 
-		if($submittedLang == false || !array_search($submittedLang,$languages)) {
+		if($submittedLang == false || !(array_search($submittedLang,$languages) || in_array('*',$languages))) {
 			$lang = "default";
 		} else {
 			$lang = $submittedLang;

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -210,8 +210,6 @@ plugin.tx_typo3forum.settings {
         disableACLs = 0
     }
 	
-	allowedLanguages = *
-	
     cutUsernameOnChar = {$plugin.tx_typo3forum.settings.cutUsernameOnChar}
     cutBreadcrumbOnChar = {$plugin.tx_typo3forum.settings.cutBreadcrumbOnChar}
     useSqlStatementsOnCriticalFunctions = {$plugin.tx_typo3forum.settings.useSqlStatementsOnCriticalFunctions}

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -209,7 +209,9 @@ plugin.tx_typo3forum.settings {
     debug {
         disableACLs = 0
     }
-
+	
+	allowedLanguages = *
+	
     cutUsernameOnChar = {$plugin.tx_typo3forum.settings.cutUsernameOnChar}
     cutBreadcrumbOnChar = {$plugin.tx_typo3forum.settings.cutBreadcrumbOnChar}
     useSqlStatementsOnCriticalFunctions = {$plugin.tx_typo3forum.settings.useSqlStatementsOnCriticalFunctions}

--- a/Resources/Private/Layouts/Bootstrap/Default.html
+++ b/Resources/Private/Layouts/Bootstrap/Default.html
@@ -10,5 +10,7 @@
 </div>
 
 <script>
-	var currentPageUid = '{f:cObject(typoscriptObjectPath: 'lib.pageUid')}';
+	currentPageUid = "{f:cObject(typoscriptObjectPath: 'lib.pageUid')}";
+	typo3_forum_ajaxUrl = "{f:uri.action(action: 'main', controller: 'Ajax', arguments:{format:'json'}, additionalParams:{eID:'typo3_forum'})}";
+	typo3_forum_ajaxUrl_helpful = "{f:uri.action(action: '__typo3_forum_action__', controller: 'Post', arguments:{post:'__typo3_forum_post__'}, additionalParams:{eID:'__typo3_forum_eid__'})}";
 </script>

--- a/Resources/Private/Layouts/Bootstrap/Default.html
+++ b/Resources/Private/Layouts/Bootstrap/Default.html
@@ -9,8 +9,4 @@
 	</div>
 </div>
 
-<script>
-	currentPageUid = "{f:cObject(typoscriptObjectPath: 'lib.pageUid')}";
-	typo3_forum_ajaxUrl = "{f:uri.action(action: 'main', controller: 'Ajax', arguments:{format:'json'}, additionalParams:{eID:'typo3_forum'})}";
-	typo3_forum_ajaxUrl_helpful = "{f:uri.action(action: '__typo3_forum_action__', controller: 'Post', arguments:{post:'__typo3_forum_post__'}, additionalParams:{eID:'__typo3_forum_eid__'})}";
-</script>
+<f:render partial="AjaxURL" />

--- a/Resources/Private/Layouts/Standard/Default.html
+++ b/Resources/Private/Layouts/Standard/Default.html
@@ -10,5 +10,7 @@
 </div>
 
 <script>
-    var currentPageUid = '{f:cObject(typoscriptObjectPath: 'lib.pageUid')}';
+    currentPageUid = "{f:cObject(typoscriptObjectPath: 'lib.pageUid')}";
+	typo3_forum_ajaxUrl = "{f:uri.action(action: 'main', controller: 'Ajax', arguments:{format:'json'}, additionalParams:{eID:'typo3_forum'})}";
+	typo3_forum_ajaxUrl_helpful = "{f:uri.action(action: '__typo3_forum_action__', controller: 'Post', arguments:{post:'__typo3_forum_post__'}, additionalParams:{eID:'__typo3_forum_eid__'})}";
 </script>

--- a/Resources/Private/Layouts/Standard/Default.html
+++ b/Resources/Private/Layouts/Standard/Default.html
@@ -9,8 +9,4 @@
     </div>
 </div>
 
-<script>
-    currentPageUid = "{f:cObject(typoscriptObjectPath: 'lib.pageUid')}";
-	typo3_forum_ajaxUrl = "{f:uri.action(action: 'main', controller: 'Ajax', arguments:{format:'json'}, additionalParams:{eID:'typo3_forum'})}";
-	typo3_forum_ajaxUrl_helpful = "{f:uri.action(action: '__typo3_forum_action__', controller: 'Post', arguments:{post:'__typo3_forum_post__'}, additionalParams:{eID:'__typo3_forum_eid__'})}";
-</script>
+<f:render partial="AjaxURL" />

--- a/Resources/Private/Partials/Bootstrap/AjaxURL.html
+++ b/Resources/Private/Partials/Bootstrap/AjaxURL.html
@@ -1,0 +1,5 @@
+<script>
+    currentPageUid = "{f:cObject(typoscriptObjectPath: 'lib.pageUid')}";
+    typo3_forum_ajaxUrl = "{f:uri.action(action: 'main', controller: 'Ajax', arguments:{format:'json'}, additionalParams:{eID:'typo3_forum'})}";
+    typo3_forum_ajaxUrl_helpful = "{f:uri.action(action: '__typo3_forum_action__', controller: 'Post', arguments:{post:'__typo3_forum_post__'}, additionalParams:{eID:'__typo3_forum_eid__'})}";
+</script>

--- a/Resources/Private/Partials/Standard/AjaxURL.html
+++ b/Resources/Private/Partials/Standard/AjaxURL.html
@@ -1,4 +1,5 @@
 <script>
+    currentPageUid = "{f:cObject(typoscriptObjectPath: 'lib.pageUid')}";
     typo3_forum_ajaxUrl = "{f:uri.action(action: 'main', controller: 'Ajax', arguments:{format:'json'}, additionalParams:{eID:'typo3_forum'})}";
     typo3_forum_ajaxUrl_helpful = "{f:uri.action(action: '__typo3_forum_action__', controller: 'Post', arguments:{post:'__typo3_forum_post__'}, additionalParams:{eID:'__typo3_forum_eid__'})}";
 </script>

--- a/Resources/Private/Partials/Standard/AjaxURL.html
+++ b/Resources/Private/Partials/Standard/AjaxURL.html
@@ -1,0 +1,4 @@
+<script>
+    typo3_forum_ajaxUrl = "{f:uri.action(action: 'main', controller: 'Ajax', arguments:{format:'json'}, additionalParams:{eID:'typo3_forum'})}";
+    typo3_forum_ajaxUrl_helpful = "{f:uri.action(action: '__typo3_forum_action__', controller: 'Post', arguments:{post:'__typo3_forum_post__'}, additionalParams:{eID:'__typo3_forum_eid__'})}";
+</script>

--- a/Resources/Public/Javascript/forum.js
+++ b/Resources/Public/Javascript/forum.js
@@ -87,11 +87,28 @@ jQuery(document).ready(function($) {
 		displayedAds['mode'] = 1;
 
 	});
-
-    if (typeof currentPageUid !== 'undefined') {
+	/* 
+		support old layout versions
+	*/
+	if(typeof typo3_forum_ajaxUrl === 'undefined'
+		&& typeof currentPageUid !== 'undefined'
+	){
+        typo3_forum_ajaxUrl = "?id=" + currentPageUid + "&eID=typo3_forum&language=de&tx_typo3forum_ajax[controller]=Ajax&tx_typo3forum_ajax[action]=main&tx_typo3forum_ajax[format]=json";
+    }
+    if(typeof typo3_forum_ajaxUrl_helpful === 'undefined'
+    	&& typeof currentPageUid !== 'undefined'
+    ){
+        typo3_forum_ajaxUrl_helpful = "index.php?id=" + currentPageUid +
+            "&eID=" + "__typo3_forum_eid__" +
+            "&tx_typo3forum_ajax[controller]=Post" +
+            "&tx_typo3forum_ajax[action]=" + "__typo3_forum_action__" +
+            "&tx_typo3forum_ajax[post]=" + "__typo3_forum_post__";
+    }
+    
+    if (typeof typo3_forum_ajaxUrl !== 'undefined') {
         $.ajax({
             type: "POST",
-            url: "?id=" + currentPageUid + "&eID=typo3_forum&language=de&tx_typo3forum_ajax[controller]=Ajax&tx_typo3forum_ajax[action]=main&tx_typo3forum_ajax[format]=json",
+            url: typo3_forum_ajaxUrl,
             async: true,
             data: {
                 "tx_typo3forum_ajax[displayedUser]": JSON.stringify(displayedUser),
@@ -162,12 +179,19 @@ jQuery(document).ready(function($) {
                     var counttargetVal = $('.' + $(targetElement).attr('data-counttarget')).html();
                     var countusertargetVal = $('.' + $(targetElement).attr('data-countusertarget')).html();
                     var type = 'add';
+                    var action = 'addSupporter';
+                    var eID  = $(this).attr('data-eid');
+                    var post = $(this).attr('data-post');
                     if ($(targetElement).hasClass('supported')) {
                         type = 'remove';
+                        action = 'removeSupporter';
                     }
                     $.ajax({
                         type: "GET",
-                        url: "index.php?id=" + currentPageUid + "&eID=" + $(this).attr('data-eid') + "&tx_typo3forum_ajax[controller]=Post&tx_typo3forum_ajax[action]=" + type + "Supporter&tx_typo3forum_ajax[post]=" + $(this).attr('data-post'),
+                        url: typo3_forum_ajaxUrl_helpful
+                                .replace('__typo3_forum_eid__', eID)
+                                .replace('__typo3_forum_action__', action)
+                                .replace('__typo3_forum_post__',post),
                         async: false,
                         beforeSend: function (msg) {
                             $('.' + $(targetElement).attr('data-counttarget')).html('<div class="tx-typo3forum-ajax-loader"></div>');


### PR DESCRIPTION
use a proper AJAX URL generated with fluid.
This solves e.g. translation problems, since the language parameter was not transferred before.
this PR is also backwards-compatible with copied/modified versions of Layouts/Default.html.